### PR TITLE
Items table hotfix. NEW COLUMN IN ITEMS TABLE

### DIFF
--- a/sql/Queststore.sql
+++ b/sql/Queststore.sql
@@ -41,6 +41,7 @@ CREATE TABLE "Item" (
   "id" INTEGER,
   "name" TEXT,
   "description" TEXT,
+  "itemType" TEXT,
   "price" REAL,
   PRIMARY KEY ("id")
 );


### PR DESCRIPTION
We forgot to add Item type column to differentiate between basic item and magic item.
This new column named "itemType" will store string "basic_Item" or "magic_item".
Thank you for your attention. 
Have a nice day.

Important message:
You all have to add this column to your local database, or delete all tables and run Queststore.sql again.